### PR TITLE
Error message

### DIFF
--- a/src/components/Dictionary.js
+++ b/src/components/Dictionary.js
@@ -52,6 +52,8 @@ function Dictionary(props) {
     search();
   }
 
+  console.log(error);
+
   if (loaded) {
     return (
       <div className="Dictionary">
@@ -68,6 +70,10 @@ function Dictionary(props) {
             Search
           </button>
         </form>
+        <div className="err-msg">
+          Seems like we don't have any definition for "{word}", please try
+          another one.
+        </div>
         <Results data={dictionaryData} />
 
         <Photos data={photosData} />

--- a/src/components/Photos.js
+++ b/src/components/Photos.js
@@ -1,7 +1,6 @@
 import React from "react";
 import "../css/Photos.css";
 function Photos(props) {
-  console.log(props);
   if (props.data) {
     return (
       <div className="Photos card">

--- a/src/css/Dictionary.css
+++ b/src/css/Dictionary.css
@@ -22,5 +22,9 @@ button {
    color: red;
    font-size: 12px;
    font-weight: 500;
-   display: none
+  
+}
+
+.display-none {
+display: none
 }

--- a/src/css/Dictionary.css
+++ b/src/css/Dictionary.css
@@ -15,3 +15,12 @@ form {
 button {
    margin-left: 7px
 }
+
+.err-msg {
+   margin-top: 20px;
+   text-align: center;
+   color: red;
+   font-size: 12px;
+   font-weight: 500;
+   display: none
+}

--- a/src/css/Photos.css
+++ b/src/css/Photos.css
@@ -13,3 +13,5 @@
  .Photos .col-4 {
     padding: 0
  }
+
+ 


### PR DESCRIPTION
Handled the case in which Pexels API can get photos for some word, but it has no definition in dictionary. 

Changes made: 
1. Added error and unknownWord states, responsible to help display error message if dictionary API has a bad response. 
2. UI Conditionally displaying an error message.
3. Changed Pexels API to try getting response only after dictionary API succeeded.

Tested, looks good. 